### PR TITLE
fix: mobile css layout

### DIFF
--- a/assets/ibis.css
+++ b/assets/ibis.css
@@ -19,15 +19,32 @@ nav {
 
 main {
     background-color: #ffffff;
-    flex-grow: 1;
-    padding-top: 0;
+    flex-grow: 2;
+    padding: 0 30px 30px 30px;
+}
+
+main .inner {
+    margin: 0 -30px;
+}
+
+nav form {
+    margin: 0.5rem 1rem 0rem 0rem;
 }
 
 .item-view {
-    padding: 0 20px 20px 20px;
     max-width: 700px;
 }
 
 pre {
     white-space: pre-wrap;
+}
+
+@media only screen and (max-width: 720px) {
+    body {
+        flex-direction: column;
+    }
+    nav input {
+        max-width: 200px;
+    }
+    nav li { display: inline-block }
 }


### PR DESCRIPTION
This is a quick and small PR that modifies to the current CSS so that it is more readable on mobile devices. It also tweaks the main wiki content's padding a tiny bit.

![2024-03-13_19-41](https://github.com/Nutomic/ibis/assets/33115327/68ba3323-2681-4684-aa8a-21550bfbd1ec)

Edit: cropped screenshot