### PR TITLE
Fix diff view in darkmode

### DIFF
--- a/src/frontend/pages/article/diff.rs
+++ b/src/frontend/pages/article/diff.rs
@@ -44,7 +44,7 @@ pub fn EditDiff() -> impl IntoView {
                         </Show>
                     </div>
                     <p>"by " {user_link(&edit.creator)}</p>
-                    <div class="p-2 my-2 bg-gray-200 rounded">
+                    <div class="max-w-full prose prose-slate">
                         <pre class="text-wrap">
                             <code>{edit.edit.diff.clone()}</code>
                         </pre>


### PR DESCRIPTION
The diff view in the history tab was unreadable in darkmode. This makes it so it has the same styling as the codeblocks in markdown